### PR TITLE
chore: bump unicocheck-ios to v2.20.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'sample-app-new' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'unicocheck-ios', '2.20.1'
+  pod 'unicocheck-ios', '2.20.2'
 
   target 'sample-app-newTests' do
     inherit! :search_paths


### PR DESCRIPTION

    ### 🚀 Automatic Update
    Bumps `unicocheck-ios` from `2.20.1` to version **2.20.2**.
    
    - 📅 **Release date**: 22/08/2025
    - 🔗 **Official Release Notes**: [https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-ios/release-notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-ios/release-notes)
    